### PR TITLE
feat: custom header validation

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -3,7 +3,7 @@
 Repository of the Dataphos Schema Registry API.
 
 
-## Registry
+## Registry 
 
 The Registry, which itself is a database with a REST API on top, is deployed as a deployment on a Kubernetes cluster
 which supports the following:


### PR DESCRIPTION
## Description

Added a new feature which allows validation of fields in the header. Header validation can be turned on on the Validator level by setting a specific variable in the config map, which requires each message to contain header schema ID and version. Otherwise, the validation fails because of missing required headers. Additionally, the header validation can be turned on/off on the single message level; it can be set by specifying the _headerValidation_ flag to true/false. If _headerValidation_ is set in message's header, Validator level flag is ignored. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (improving code structure without changing external behavior)
- [ ] Other (please explain):

## Related Issue

- Fixes #14

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My code is well documented
- [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)

## How Has This Been Tested?

This has been tested by setting the Validator' header validation flag to true and false. A set of messages was sent; these messages contained the same payload, but different headers. The cases that were tested are the following:
- no new headers
- only _headerValidation_ header set, no _headerSchemaId_ and _headerVersionId_
-  _headerSchemaId_ and _headerVersionId_ set, but _headerValidation_ not set
- _headerValidation_ set to true/false, but missing one of _headerSchemaId_ or _headerVersionId_
- all 3 headers set
All headers that provided sufficient info were validated correctly and in case of an error, all error messages and error codes were displayed correctly.
