### PR TITLE
feat: custom header validation

### DIFF
--- a/validator/internal/centralconsumer/centralconsumer.go
+++ b/validator/internal/centralconsumer/centralconsumer.go
@@ -307,8 +307,15 @@ func (cc *CentralConsumer) Handle(ctx context.Context, message janitor.Message) 
 		encryptedMessageData  []byte
 	)
 
+	// header validation is turned on if a message specifies so in the header OR if validateHeaders flag is set
+	// on the Validator level
 	if message.RawAttributes[janitor.HeaderValidation] == "true" ||
 		(cc.validateHeaders == true && message.RawAttributes[janitor.HeaderValidation] != "false") {
+		_, ok := cc.Validators["json"]
+		// it is possible json validator isn't initialized by this point so we are checking it just in case
+		if !ok {
+			cc.Validators["json"] = jsoninternal.New()
+		}
 		var (
 			headerId      string
 			headerVersion string

--- a/validator/internal/config/centralconsumer.go
+++ b/validator/internal/config/centralconsumer.go
@@ -30,6 +30,7 @@ type CentralConsumer struct {
 	ShouldLog              CentralConsumerShouldLog  `toml:"should_log"`
 	NumSchemaCollectors    int                       `toml:"num_schema_collectors" default:"-1"`
 	NumInferrers           int                       `toml:"num_inferrers" default:"-1"`
+	ValidateHeaders        bool                      `toml:"validate_headers"`
 	MetricsLoggingInterval time.Duration             `toml:"metrics_logging_interval" default:"5s"`
 	RunOptions             RunOptions                `toml:"run_option"`
 	Mode                   int                       `toml:"mode"`

--- a/validator/internal/errcodes/errcodes.go
+++ b/validator/internal/errcodes/errcodes.go
@@ -77,6 +77,9 @@ const (
 	// CompletedWithErrors marks that the process has completed but errors occurred.
 	CompletedWithErrors = 904
 
+	// MissingHeader declares that something in the header is missing
+	MissingHeader = 906
+
 	// Miscellaneous is used when no other available error code is fitting.
 	Miscellaneous = 999
 )

--- a/validator/internal/janitor/janitor.go
+++ b/validator/internal/janitor/janitor.go
@@ -133,12 +133,12 @@ func GetHeaderIdAndVersion(message Message) (string, string, error) {
 
 func ValidateHeader(message Message, schema []byte, validators Validators) (bool, error) {
 	if len(schema) == 0 {
-		errMissingSchema := errors.WithMessage(validator.ErrMissingSchema, "")
+		errMissingHeaderSchema := errors.WithMessage(validator.ErrMissingHeaderSchema, "")
 		message.RawAttributes["deadLetterErrorCategory"] = "Header schema error"
-		message.RawAttributes["deadLetterErrorReason"] = errMissingSchema.Error()
+		message.RawAttributes["deadLetterErrorReason"] = errMissingHeaderSchema.Error()
 		return false, nil
 	}
-	headerData, err := json.Marshal(message.RawAttributes)
+	headerData, err := generateHeaderData(message.RawAttributes)
 	if err != nil {
 		message.RawAttributes["deadLetterErrorCategory"] = "Header schema error"
 		message.RawAttributes["deadLetterErrorReason"] = err.Error()
@@ -158,7 +158,7 @@ func ValidateHeader(message Message, schema []byte, validators Validators) (bool
 	if err != nil {
 		if errors.Is(err, validator.ErrFailedValidation) {
 			message.RawAttributes["deadLetterErrorCategory"] = "Header validation error"
-			message.RawAttributes["deadLetterErrorReason"] = err.Error()
+			message.RawAttributes["deadLetterErrorReason"] = errors.WithMessage(validator.ErrFailedHeaderValidation, err.Error())
 			return false, nil
 		} else if errors.Is(err, validator.ErrDeadletter) {
 			return false, nil

--- a/validator/internal/janitor/janitor.go
+++ b/validator/internal/janitor/janitor.go
@@ -172,6 +172,23 @@ func ValidateHeader(message Message, schema []byte, validators Validators) (bool
 	return false, nil
 }
 
+func generateHeaderData(rawAttributes map[string]interface{}) ([]byte, error) {
+	cleanAttributes := make(map[string]interface{})
+	for key, value := range rawAttributes {
+		if key == HeaderValidation || key == AttributeHeaderID || key == AttributeHeaderVersion ||
+			key == AttributeSchemaID || key == AttributeSchemaVersion || key == AttributeFormat {
+			continue
+		} else {
+			cleanAttributes[key] = value
+		}
+	}
+	headerData, err := json.Marshal(cleanAttributes)
+	if err != nil {
+		return nil, err
+	}
+	return headerData, nil
+}
+
 // SchemaGenerators is a convenience type for a map containing schemagen.Generator instances for available message formats.
 type SchemaGenerators map[string]schemagen.Generator
 

--- a/validator/internal/janitor/janitor.go
+++ b/validator/internal/janitor/janitor.go
@@ -18,6 +18,7 @@ package janitor
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -35,18 +36,19 @@ import (
 // Message defines a Message used for processing broker messages.
 // Essentially, Message decorates broker messages with additional, extracted information.
 type Message struct {
-	ID            string
-	Key           string
-	RawAttributes map[string]interface{}
-	Payload       []byte
-	IngestionTime time.Time
-	SchemaID      string
-	Version       string
-	Format        string
+	ID               string
+	Key              string
+	RawAttributes    map[string]interface{}
+	Payload          []byte
+	IngestionTime    time.Time
+	SchemaID         string
+	Version          string
+	Format           string
+	HeaderValidation bool
 }
 
 const (
-	// AttributeSchemaID is one of the keys expected to beł found in the attributes field of the message.
+	// AttributeSchemaID is one of the keys expected to be found in the attributes field of the message.
 	// It holds the schema id information concerning the data field of the message
 	AttributeSchemaID = "schemaId"
 
@@ -57,6 +59,18 @@ const (
 	// AttributeFormat is one of the keys expected to be found in the attributes field of the message.
 	// It holds the format of the data field of the message.
 	AttributeFormat = "format"
+
+	// HeaderValidation is one of the keys that can occur in raw attributes section of header.
+	// It determines if the header will be validated
+	HeaderValidation = "headerValidation"
+
+	// AttributeHeaderID is one of the keys expected in raw attributes section of header, but only if HeaderValidation is true.
+	// It holds the header's schema id that is used to check header validity
+	AttributeHeaderID = "headerSchemaId"
+
+	// AttributeHeaderVersion is one of the keys expected in raw attributes section of header, but only if HeaderValidation is true.
+	// It holds the header's schema version that is used to check header validity
+	AttributeHeaderVersion = "headerVersionId"
 )
 
 // MessageSchemaPair wraps a Message with the Schema relating to this Message.
@@ -65,27 +79,27 @@ type MessageSchemaPair struct {
 	Schema  []byte
 }
 
-// CollectSchema retrieves the schema of the given Message from registry.SchemaRegistry.
+// CollectSchema retrieves the schema with the given id and version from registry.SchemaRegistry.
 //
-// If schema retrieval results in registry.ErrNotFound, or Message.SchemaID or Message.Version is an empty string,
+// If schema retrieval results in registry.ErrNotFound, or id or version are an empty string,
 // the Message is put on the results channel with MessageSchemaPair.Schema set to nil.
 //
 // The returned error is an instance of OpError for improved error handling (so that the source of this error is identifiable
 // even if combined with other errors).
-func CollectSchema(ctx context.Context, message Message, schemaRegistry registry.SchemaRegistry) (MessageSchemaPair, error) {
-	if message.SchemaID == "" || message.Version == "" {
-		return MessageSchemaPair{Message: message, Schema: nil}, nil
+func CollectSchema(ctx context.Context, id string, version string, schemaRegistry registry.SchemaRegistry) ([]byte, error) {
+	if id == "" || version == "" {
+		return nil, nil
 	}
 
-	schema, err := schemaRegistry.Get(ctx, message.SchemaID, message.Version)
+	schema, err := schemaRegistry.Get(ctx, id, version)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotFound) {
-			return MessageSchemaPair{Message: message, Schema: nil}, nil
+			return nil, nil
 		}
-		return MessageSchemaPair{}, intoOpErr(message.ID, errcodes.RegistryUnresponsive, err)
+		return nil, intoOpErr(id, errcodes.RegistryUnresponsive, err)
 	}
 
-	return MessageSchemaPair{Message: message, Schema: schema}, nil
+	return schema, nil
 }
 
 // Validators is a convenience type for a map containing validator.Validator instances for available message formats.
@@ -101,6 +115,61 @@ func (vs Validators) Validate(message Message, schema []byte) (bool, error) {
 		return false, errtemplates.UnsupportedMessageFormat(message.Format)
 	}
 	return v.Validate(message.Payload, schema, message.SchemaID, message.Version)
+}
+
+func GetHeaderIdAndVersion(message Message) (string, string, error) {
+	var id string
+	var version string
+	var ok bool
+
+	if id, ok = message.RawAttributes[AttributeHeaderID].(string); !ok {
+		return "", "", intoOpErr(message.ID, errcodes.MissingHeader, errors.New("missing header ID"))
+	}
+	if version, ok = message.RawAttributes[AttributeHeaderVersion].(string); !ok {
+		return "", "", intoOpErr(message.ID, errcodes.MissingHeader, errors.New("missing header version"))
+	}
+	return id, version, nil
+}
+
+func ValidateHeader(message Message, schema []byte, validators Validators) (bool, error) {
+	if len(schema) == 0 {
+		errMissingSchema := errors.WithMessage(validator.ErrMissingSchema, "")
+		message.RawAttributes["deadLetterErrorCategory"] = "Header schema error"
+		message.RawAttributes["deadLetterErrorReason"] = errMissingSchema.Error()
+		return false, nil
+	}
+	headerData, err := json.Marshal(message.RawAttributes)
+	if err != nil {
+		message.RawAttributes["deadLetterErrorCategory"] = "Header schema error"
+		message.RawAttributes["deadLetterErrorReason"] = err.Error()
+		return false, err
+	}
+
+	headerSchemaId, ok := message.RawAttributes[AttributeHeaderID].(string)
+	if !ok {
+		return false, errors.New("header ID is not in a supported format")
+	}
+	headerSchemaVersion, ok := message.RawAttributes[AttributeHeaderVersion].(string)
+	if !ok {
+		return false, errors.New("header version is not in a supported format")
+	}
+
+	isValid, err := validators["json"].Validate(headerData, schema, headerSchemaId, headerSchemaVersion)
+	if err != nil {
+		if errors.Is(err, validator.ErrFailedValidation) {
+			message.RawAttributes["deadLetterErrorCategory"] = "Header validation error"
+			message.RawAttributes["deadLetterErrorReason"] = err.Error()
+			return false, nil
+		} else if errors.Is(err, validator.ErrDeadletter) {
+			return false, nil
+		}
+		return false, intoOpErr(message.ID, errcodes.ValidationFailure, err)
+	}
+
+	if isValid {
+		return true, nil
+	}
+	return false, nil
 }
 
 // SchemaGenerators is a convenience type for a map containing schemagen.Generator instances for available message formats.

--- a/validator/internal/janitor/parse.go
+++ b/validator/internal/janitor/parse.go
@@ -15,8 +15,8 @@
 package janitor
 
 import (
-	"github.com/dataphos/schema-registry-validator/internal/errtemplates"
 	"github.com/dataphos/lib-streamproc/pkg/streamproc"
+	"github.com/dataphos/schema-registry-validator/internal/errtemplates"
 )
 
 // ParseMessage parses a given broker.Message into Message, by setting Message.Payload to the value of the data field of the given

--- a/validator/internal/janitorctl/run.go
+++ b/validator/internal/janitorctl/run.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"runtime/debug"
 
+	"github.com/dataphos/lib-brokers/pkg/broker"
+	"github.com/dataphos/lib-logger/logger"
+	"github.com/dataphos/lib-logger/standardlogger"
+	"github.com/dataphos/lib-shutdown/pkg/graceful"
 	"github.com/dataphos/schema-registry-validator/internal/centralconsumer"
 	"github.com/dataphos/schema-registry-validator/internal/config"
 	"github.com/dataphos/schema-registry-validator/internal/errcodes"
 	"github.com/dataphos/schema-registry-validator/internal/janitor"
 	"github.com/dataphos/schema-registry-validator/internal/pullercleaner"
 	"github.com/dataphos/schema-registry-validator/internal/registry"
-	"github.com/dataphos/lib-brokers/pkg/broker"
-	"github.com/dataphos/lib-logger/logger"
-	"github.com/dataphos/lib-logger/standardlogger"
-	"github.com/dataphos/lib-shutdown/pkg/graceful"
 )
 
 type ProcessorInitFunc func(context.Context, registry.SchemaRegistry, broker.Publisher) (*janitor.Processor, error)
@@ -86,6 +86,7 @@ func RunCentralConsumer(configFile string) {
 			centralconsumer.Settings{
 				NumSchemaCollectors: cfg.NumSchemaCollectors,
 				NumInferrers:        cfg.NumInferrers,
+				ValidateHeaders:     cfg.ValidateHeaders,
 			},
 			log,
 			centralconsumer.RouterFlags{

--- a/validator/internal/validator/validator.go
+++ b/validator/internal/validator/validator.go
@@ -24,13 +24,19 @@ var ErrDeadletter = errors.New("deadletter")
 var ErrBrokenMessage = errors.New("Message is not in valid format")
 
 // ErrWrongCompile is a special error type to help distinguish messages that had fault while compiling.
-var ErrWrongCompile = errors.New("There is an error while compiling.")
+var ErrWrongCompile = errors.New("There is an error while compiling")
 
 // ErrMissingSchema is a special error type to help distinguish messages that are missing schema.
 var ErrMissingSchema = errors.New("Message is missing a schema")
 
+// ErrMissingHeaderSchema is a special error type to help distinguish headers that are missing schema (header validation).
+var ErrMissingHeaderSchema = errors.New("Header is missing a schema")
+
 // ErrFailedValidation is a special error type to help distinguish messages that have failed in validation.
-var ErrFailedValidation = errors.New("An error occured while validating message.")
+var ErrFailedValidation = errors.New("An error occured while validating message")
+
+// ErrFailedHeaderValidation is a special error type to help distinguish messages' headers that have failed in validation.
+var ErrFailedHeaderValidation = errors.New("An error occured while validating message's header")
 
 // Validator is the interface used to model message validators.
 type Validator interface {


### PR DESCRIPTION
## Description

Added a new feature which allows validation of fields in the header. Header validation can be turned on on the Validator level by setting a specific variable in the config map, which requires each message to contain header schema ID and version. Otherwise, the validation fails because of missing required headers. Additionally, the header validation can be turned on/off on the single message level; it can be set by specifying the _headerValidation_ flag to true/false. If _headerValidation_ is set in message's header, Validator level flag is ignored. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (improving code structure without changing external behavior)
- [ ] Other (please explain):

## Related Issue

- Fixes #14

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My code is well documented
- [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)

## How Has This Been Tested?

This has been tested by setting the Validator' header validation flag to true and false. A set of messages was sent; these messages contained the same payload, but different headers. The cases that were tested are the following:
- no new headers
- only _headerValidation_ header set, no _headerSchemaId_ and _headerVersionId_
-  _headerSchemaId_ and _headerVersionId_ set, but _headerValidation_ not set
- _headerValidation_ set to true/false, but missing one of _headerSchemaId_ or _headerVersionId_
- all 3 headers set
All headers that provided sufficient info were validated correctly and in case of an error, all error messages and error codes were displayed correctly.
